### PR TITLE
#17 canvas clear selection added

### DIFF
--- a/src/pods/canvas/canvas.pod.tsx
+++ b/src/pods/canvas/canvas.pod.tsx
@@ -11,7 +11,7 @@ export const CanvasPod = () => {
     createShape(90, 170, 250, 50),
   ]);
 
-  const { shapeRefs, transformerRef, handleSelected } = useSelection(shapes);
+  const { shapeRefs, transformerRef, handleSelected, handleClearSelection } = useSelection(shapes);
 
   const handleDragEnd =
     (id: string) => (e: Konva.KonvaEventObject<DragEvent>) => {
@@ -23,12 +23,16 @@ export const CanvasPod = () => {
       );
     };
 
+  
   return (
     <>
       {/*TODO: harcoded border, once final layout is ready, remove this*/}
       <div style={{ border: "1px solid black" }}>
         {/*TODO: right now harcoded values, remove this once we have final layout*/}
-        <Stage width={1024} height={800}>
+        <Stage width={1024} height={800} 
+        onMouseDown={handleClearSelection}
+        onTouchStart={handleClearSelection}
+        >
           <Layer>
             {
               /* TODO compentize and simplify this */

--- a/src/pods/canvas/use-selection.hook.ts
+++ b/src/pods/canvas/use-selection.hook.ts
@@ -21,8 +21,15 @@ export const useSelection = (shapes: ShapeModel[]) => {
   }, [shapes]);
 
   const handleSelected = (id: string) => {
-    transformerRef?.current?.nodes([shapeRefs.current[id].current]);
+    transformerRef?.current?.nodes([shapeRefs.current[id].current]);    
   };
 
-  return { transformerRef, shapeRefs, handleSelected };
+
+  const handleClearSelection = (mouseEvent : Konva.KonvaEventObject<MouseEvent> |  Konva.KonvaEventObject<TouchEvent>) => {
+    if (mouseEvent.target === mouseEvent.target.getStage()) {
+      transformerRef.current?.nodes([]);      
+    }
+  }
+
+  return { transformerRef, shapeRefs, handleSelected, handleClearSelection };
 };


### PR DESCRIPTION
Added feature: Canvas clear selection

Here, I improved the code in the "use-selection.hook.ts" hook to deselect shapes previously selected from the transformerRef when the user clicks on the canvas.

Regards!

Closes #17 