### PR TITLE
Feature#96 add footer with zoom info

### DIFF
--- a/src/layout/main.layout.module.css
+++ b/src/layout/main.layout.module.css
@@ -1,11 +1,13 @@
 .layout {
   display: grid;
-  grid-template-columns:
-    minmax(var(--column-min-size), 2fr) minmax(var(--canvas-min-size), 8fr)
-    minmax(var(--column-min-size), 2fr);
-  grid-template-rows: auto 8fr;
+  grid-template-columns: minmax(var(--column-min-size), 2fr) minmax(
+      var(--canvas-min-size),
+      8fr
+    ) minmax(var(--column-min-size), 2fr);
+  grid-template-rows: auto minmax(0, 1fr) auto;
   grid-template-areas:
     'toolbar toolbar toolbar'
-    'container-gallery canvas component-gallery';
+    'components-gallery canvas properties-options'
+    'footer footer footer';
   height: 100vh;
 }

--- a/src/pods/component-gallery/component-gallery.pod.tsx
+++ b/src/pods/component-gallery/component-gallery.pod.tsx
@@ -4,7 +4,7 @@ import { mockWidgetCollection } from './component-gallery-data';
 
 export const ComponentGalleryPod = () => {
   return (
-    <div className={classes.component}>
+    <div className={classes.container}>
       <div className={classes.title}>
         <p>Components</p>
       </div>

--- a/src/pods/component-gallery/component.pod.module.css
+++ b/src/pods/component-gallery/component.pod.module.css
@@ -4,6 +4,8 @@
 }
 
 .title {
+  position: sticky;
+  top: 0;
   background-color: var(--primary-200);
   padding: var(--space-xs) var(--space-md);
   border-top: 1px solid var(--primary-900);

--- a/src/pods/container-gallery/container-gallery.pod.tsx
+++ b/src/pods/container-gallery/container-gallery.pod.tsx
@@ -6,7 +6,7 @@ export const ContainerGalleryPod = () => {
   return (
     <div className={classes.container}>
       <div className={classes.title}>
-        <p>Containers</p>
+        <p>Devices</p>
       </div>
       <GalleryComponent itemCollection={mockContainerCollection} />
     </div>

--- a/src/pods/container-gallery/container.pod.module.css
+++ b/src/pods/container-gallery/container.pod.module.css
@@ -4,6 +4,8 @@
 }
 
 .title {
+  position: sticky;
+  top: 0;
   background-color: var(--primary-200);
   padding: var(--space-xs) var(--space-md);
   border-bottom: 1px solid var(--primary-900);

--- a/src/pods/footer/components/index.ts
+++ b/src/pods/footer/components/index.ts
@@ -1,0 +1,2 @@
+export * from './zoom-in-button';
+export * from './zoom-out-button';

--- a/src/pods/footer/components/zoom-in-button.tsx
+++ b/src/pods/footer/components/zoom-in-button.tsx
@@ -1,0 +1,23 @@
+import { ZoomInIcon } from '@/common/components/icons/zoom-in.component';
+
+interface ZoomInButtonProps {
+  scale: number;
+  setScale: React.Dispatch<React.SetStateAction<number>>;
+  className: string;
+}
+
+export const ZoomInButton: React.FC<ZoomInButtonProps> = props => {
+  const { scale, setScale, className } = props;
+
+  const handleClick = () => {
+    setScale(prevScale => Number(Math.min(1.5, prevScale + 0.1).toFixed(1)));
+  };
+
+  const isDisabled = scale >= 1.5;
+
+  return (
+    <button onClick={handleClick} className={className} disabled={isDisabled}>
+      <ZoomInIcon />
+    </button>
+  );
+};

--- a/src/pods/footer/components/zoom-out-button.tsx
+++ b/src/pods/footer/components/zoom-out-button.tsx
@@ -1,0 +1,23 @@
+import { ZoomOutIcon } from '@/common/components/icons/zoom-out.component';
+
+interface ZoomOutButtonProps {
+  scale: number;
+  setScale: React.Dispatch<React.SetStateAction<number>>;
+  className: string;
+}
+
+export const ZoomOutButton: React.FC<ZoomOutButtonProps> = props => {
+  const { scale, setScale, className } = props;
+
+  const handleClick = () => {
+    setScale(prevScale => Number(Math.max(0.5, prevScale - 0.1).toFixed(1)));
+  };
+
+  const isDisabled = scale <= 0.5;
+
+  return (
+    <button onClick={handleClick} className={className} disabled={isDisabled}>
+      <ZoomOutIcon />
+    </button>
+  );
+};

--- a/src/pods/footer/footer.pod.module.css
+++ b/src/pods/footer/footer.pod.module.css
@@ -1,0 +1,53 @@
+.container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: var(--primary-50);
+  border-top: 1px solid var(--primary-100);
+  padding: var(--space-xs) var(--space-md);
+}
+
+.title {
+  flex-grow: 1;
+}
+
+.zoomContainer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-xs);
+}
+
+.zoomValue {
+  min-width: 50px;
+  text-align: center;
+}
+
+.button {
+  border: none;
+  color: var(--text-color);
+  background-color: inherit;
+  padding: var(--space-s);
+  border-radius: var(--border-radius-m);
+  font-size: var(--fs-xs);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-s);
+  transition: all 0.3s ease-in-out;
+  cursor: pointer;
+}
+
+.button:hover {
+  background-color: var(--primary-100);
+}
+
+.button:disabled {
+  color: var(--primary-300);
+  cursor: not-allowed;
+}
+
+.button:disabled:hover {
+  background-color: inherit;
+}

--- a/src/pods/footer/footer.pod.tsx
+++ b/src/pods/footer/footer.pod.tsx
@@ -1,0 +1,26 @@
+import { useCanvasContext } from '@/core/providers';
+import classes from './footer.pod.module.css';
+import { ZoomInButton, ZoomOutButton } from './components';
+
+export const FooterPod = () => {
+  const { scale, setScale } = useCanvasContext();
+
+  return (
+    <footer className={classes.container}>
+      <p className={classes.title}>Quickmock - © Lemoncode</p>
+      <div className={classes.zoomContainer}>
+        <ZoomOutButton
+          scale={scale}
+          setScale={setScale}
+          className={classes.button}
+        />
+        <p className={classes.zoomValue}>{(scale * 100).toFixed(0)} %</p>
+        <ZoomInButton
+          scale={scale}
+          setScale={setScale}
+          className={classes.button}
+        />
+      </div>
+    </footer>
+  );
+};

--- a/src/pods/toolbar/components/toolbar-button/toolbar-button.tsx
+++ b/src/pods/toolbar/components/toolbar-button/toolbar-button.tsx
@@ -2,14 +2,16 @@ interface Props {
   children: React.ReactNode;
   onClick?: () => void;
   className?: string;
+  disabled?: boolean;
 }
 export const ToolbarButton: React.FC<Props> = ({
   children,
   onClick,
   className,
+  disabled,
 }) => {
   return (
-    <button onClick={onClick} className={className}>
+    <button onClick={onClick} className={className} disabled={disabled}>
       {children}
     </button>
   );

--- a/src/pods/toolbar/components/zoom-in-button/zoom-in-button.tsx
+++ b/src/pods/toolbar/components/zoom-in-button/zoom-in-button.tsx
@@ -4,14 +4,20 @@ import { ZoomInIcon } from '@/common/components/icons/zoom-in.component';
 import { useCanvasContext } from '@/core/providers';
 
 export const ZoomInButton = () => {
-  const { setScale } = useCanvasContext();
+  const { scale, setScale } = useCanvasContext();
 
   const handleClick = () => {
-    setScale(prevScale => prevScale * 1.1);
+    setScale(prevScale => Number(Math.min(1.5, prevScale + 0.1).toFixed(1)));
   };
 
+  const isDisabled = scale >= 1.5;
+
   return (
-    <ToolbarButton onClick={handleClick} className={classes.button}>
+    <ToolbarButton
+      onClick={handleClick}
+      className={classes.button}
+      disabled={isDisabled}
+    >
       <ZoomInIcon />
       <span>Zoom In</span>
     </ToolbarButton>

--- a/src/pods/toolbar/components/zoom-out-component/zoom-out-button.tsx
+++ b/src/pods/toolbar/components/zoom-out-component/zoom-out-button.tsx
@@ -4,14 +4,20 @@ import classes from '@/pods/toolbar/toolbar.pod.module.css';
 import { useCanvasContext } from '@/core/providers';
 
 export const ZoomOutButton = () => {
-  const { setScale } = useCanvasContext();
+  const { scale, setScale } = useCanvasContext();
 
   const handleClick = () => {
-    setScale(prevScale => prevScale * 0.9);
+    setScale(prevScale => Number(Math.max(0.5, prevScale - 0.1).toFixed(1)));
   };
 
+  const isDisabled = scale <= 0.5;
+
   return (
-    <ToolbarButton onClick={handleClick} className={classes.button}>
+    <ToolbarButton
+      onClick={handleClick}
+      className={classes.button}
+      disabled={isDisabled}
+    >
       <ZoomOutIcon />
       <span>Zoom Out</span>
     </ToolbarButton>

--- a/src/pods/toolbar/toolbar.pod.module.css
+++ b/src/pods/toolbar/toolbar.pod.module.css
@@ -22,9 +22,11 @@
   transition: all 0.3s ease-in-out;
   cursor: pointer;
 }
+
 .button svg {
   font-size: var(--fs-s);
 }
+
 .button:focus-visible {
   outline: 1px auto var(--primary-500);
 }
@@ -32,4 +34,13 @@
 .button:hover {
   background-color: var(--primary-900);
   color: var(--pure-white);
+}
+
+.button:disabled {
+  color: var(--primary-300);
+  cursor: not-allowed;
+}
+
+.button:disabled:hover {
+  background-color: inherit;
 }

--- a/src/pods/toolbar/toolbar.pod.tsx
+++ b/src/pods/toolbar/toolbar.pod.tsx
@@ -17,8 +17,8 @@ export const ToolbarPod: React.FC = () => {
       <NewButton />
       <OpenButton />
       <SaveButton />
-      <ZoomInButton />
       <ZoomOutButton />
+      <ZoomInButton />
       <UndoButton />
       <RedoButton />
       <ExportButton />

--- a/src/scenes/main.module.css
+++ b/src/scenes/main.module.css
@@ -1,10 +1,13 @@
-.containerGallery {
-    grid-area: container-gallery;
-    border-right: 1px solid black;
+.componentsGallery {
+  grid-area: components-gallery;
+  border-right: 1px solid black;
 }
 
-.componentGallery {
-    grid-area: component-gallery;
-    border-left: 1px solid black;
+.propertiesOptions {
+  grid-area: properties-options;
+  border-left: 1px solid black;
 }
 
+.footer {
+  grid-area: footer;
+}

--- a/src/scenes/main.scene.tsx
+++ b/src/scenes/main.scene.tsx
@@ -8,19 +8,23 @@ import {
   ComponentGalleryPod,
 } from '@/pods';
 import { PropertiesPod } from '@/pods/properties';
+import { FooterPod } from '@/pods/footer/footer.pod';
 
 export const MainScene = () => {
   return (
     <MainLayout>
       <ToolbarPod />
-      <div className={classes.containerGallery}>
+      <div className={classes.componentsGallery}>
         <ContainerGalleryPod />
         <ComponentGalleryPod />
       </div>
-      <div className={classes.componentGallery}>
+      <CanvasPod />
+      <div className={classes.propertiesOptions}>
         <PropertiesPod />
       </div>
-      <CanvasPod />
+      <div className={classes.footer}>
+        <FooterPod />
+      </div>
     </MainLayout>
   );
 };


### PR DESCRIPTION
It has 3 different commits, the first one modify the initial grid in case @deletidev wants to take a look at it. There was a className in component-gallery.pod.tsx that wasn't being applied, now the app preserves the 100vh without scrolls.

closes #96 