### PR TITLE
#150 line shape created

### DIFF
--- a/public/shapes/line.svg
+++ b/public/shapes/line.svg
@@ -1,0 +1,4 @@
+<svg width="200" height="50" xmlns="http://www.w3.org/2000/svg">
+  <!-- Línea -->
+  <line x1="10" y1="25" x2="190" y2="25" style="stroke:black;stroke-width:2"/>
+</svg>

--- a/src/common/components/front-basic-sapes/index.ts
+++ b/src/common/components/front-basic-sapes/index.ts
@@ -1,2 +1,3 @@
 export * from './rectangle-basic-shape';
 export * from './diamond-shape';
+export * from './line-basic-shape';

--- a/src/common/components/front-basic-sapes/line-basic-shape.tsx
+++ b/src/common/components/front-basic-sapes/line-basic-shape.tsx
@@ -1,0 +1,51 @@
+import { forwardRef } from 'react';
+import { Group, Line, Rect } from 'react-konva';
+import { ShapeSizeRestrictions } from '@/core/model';
+import { fitSizeToShapeSizeRestrictions } from '@/common/utils/shapes/shape-restrictions';
+import { ShapeProps } from '../front-components/shape.model';
+
+const lineShapeRestrictions: ShapeSizeRestrictions = {
+  minWidth: 50,
+  minHeight: 10,
+  maxWidth: -1,
+  maxHeight: 10,
+  defaultWidth: 200,
+  defaultHeight: 10,
+};
+
+export const getlineShapeRestrictions = (): ShapeSizeRestrictions =>
+  lineShapeRestrictions;
+
+export const LineShape = forwardRef<any, ShapeProps>(
+  ({ x, y, width, height, id, onSelected, text, ...shapeProps }, ref) => {
+    const { width: restrictedWidth, height: restrictedHeight } =
+      fitSizeToShapeSizeRestrictions(lineShapeRestrictions, width, height);
+
+    return (
+      <Group
+        x={x}
+        y={y}
+        ref={ref}
+        width={restrictedWidth}
+        height={restrictedHeight}
+        {...shapeProps}
+        onClick={() => onSelected(id, 'line')}
+      >
+        {/* Transparent rectangle for applying margin */}
+        <Rect
+          width={restrictedWidth}
+          height={restrictedHeight}
+          fill="transparent"
+        />
+
+        <Line
+          x={0}
+          y={restrictedHeight / 2}
+          points={[0, 0, restrictedWidth, 0]}
+          stroke="black"
+          strokeWidth={2}
+        />
+      </Group>
+    );
+  }
+);

--- a/src/core/model/index.ts
+++ b/src/core/model/index.ts
@@ -54,6 +54,7 @@ export interface ShapeModel {
   height: number;
   type: ShapeType;
   allowsInlineEdition: boolean;
+  hasLateralTransformer: boolean;
   editType?: EditType;
   text?: string;
 }

--- a/src/core/model/index.ts
+++ b/src/core/model/index.ts
@@ -26,7 +26,8 @@ export type ShapeType =
   | 'radiobutton'
   | 'rectangle'
   | 'videoPlayer'
-  | 'diamond';
+  | 'diamond'
+  | 'line';
 /* | "text"| "button" |  "radio" | "image"*/
 
 export type EditType = 'input' | 'textarea';

--- a/src/pods/basic-shapes-gallery/basic-gallery-data/index.ts
+++ b/src/pods/basic-shapes-gallery/basic-gallery-data/index.ts
@@ -3,4 +3,5 @@ import { ItemInfo } from '@/common/components/gallery/components/model';
 export const mockBasicShapesCollection: ItemInfo[] = [
   { thumbnailSrc: '/shapes/rectangle.svg', type: 'rectangle' },
   { thumbnailSrc: '/shapes/diamond.svg', type: 'diamond' },
+  { thumbnailSrc: '/shapes/line.svg', type: 'line' },
 ];

--- a/src/pods/canvas/canvas.model.ts
+++ b/src/pods/canvas/canvas.model.ts
@@ -131,6 +131,15 @@ const doesShapeAllowInlineEdition = (shapeType: ShapeType): boolean => {
   }
 };
 
+const doesShapeHaveLateralTransformer = (shapeType: ShapeType): boolean => {
+  switch (shapeType) {
+    case 'line':
+      return true;
+    default:
+      return false;
+  }
+};
+
 const generateDefaultTextValue = (shapeType: ShapeType): string | undefined => {
   switch (shapeType) {
     case 'input':
@@ -174,6 +183,7 @@ export const createShape = (coord: Coord, shapeType: ShapeType): ShapeModel => {
     height,
     type: shapeType,
     allowsInlineEdition: doesShapeAllowInlineEdition(shapeType),
+    hasLateralTransformer: doesShapeHaveLateralTransformer(shapeType),
     text: generateDefaultTextValue(shapeType),
     editType: getShapeEditInlineType(shapeType),
   };

--- a/src/pods/canvas/canvas.model.ts
+++ b/src/pods/canvas/canvas.model.ts
@@ -21,6 +21,7 @@ import { getLabelSizeRestrictions } from '@/common/components/front-components/l
 import {
   getDiamondShapeSizeRestrictions,
   getRectangleShapeSizeRestrictions,
+  getlineShapeRestrictions,
 } from '@/common/components/front-basic-sapes';
 import { getVideoPlayerShapeSizeRestrictions } from '@/common/components/front-rich-components';
 
@@ -106,6 +107,11 @@ export const getDefaultSizeFromShape = (shapeType: ShapeType): Size => {
       return {
         width: getDiamondShapeSizeRestrictions().defaultWidth,
         height: getDiamondShapeSizeRestrictions().defaultHeight,
+      };
+    case 'line':
+      return {
+        width: getlineShapeRestrictions().defaultWidth,
+        height: getlineShapeRestrictions().defaultHeight,
       };
     default:
       return { width: 200, height: 50 };

--- a/src/pods/canvas/canvas.pod.tsx
+++ b/src/pods/canvas/canvas.pod.tsx
@@ -72,12 +72,7 @@ export const CanvasPod = () => {
   } = useSnapIn(transformerRef, selectedShapeKonvaId);
 
   const { handleTransform, handleTransformerBoundBoxFunc } = useTransform(
-    updateShapeSizeAndPosition,
-    {
-      selectedShapeRef,
-      selectedShapeId,
-      selectedShapeType,
-    }
+    updateShapeSizeAndPosition
   );
 
   const handleDragEnd =

--- a/src/pods/canvas/shape-renderer/index.tsx
+++ b/src/pods/canvas/shape-renderer/index.tsx
@@ -20,9 +20,12 @@ import {
   renderMobilePhoneContainer,
   renderTablet,
 } from './simple-container';
-import { renderRectangle } from './simple-basic-shapes/rectangle.rerender';
 import { renderVideoPlayer } from './simple-rich-components';
-import { renderDiamond } from './simple-basic-shapes';
+import {
+  renderDiamond,
+  renderRectangle,
+  renderLine,
+} from './simple-basic-shapes';
 
 export const renderShapeComponent = (
   shape: ShapeModel,
@@ -65,6 +68,8 @@ export const renderShapeComponent = (
       return renderVideoPlayer(shape, shapeRenderedProps);
     case 'diamond':
       return renderDiamond(shape, shapeRenderedProps);
+    case 'line':
+      return renderLine(shape, shapeRenderedProps);
     default:
       return renderNotFound(shape, shapeRenderedProps);
   }

--- a/src/pods/canvas/shape-renderer/simple-basic-shapes/index.ts
+++ b/src/pods/canvas/shape-renderer/simple-basic-shapes/index.ts
@@ -1,2 +1,3 @@
 export * from './rectangle.rerender';
 export * from './diamond.renderer';
+export * from './line.renderer';

--- a/src/pods/canvas/shape-renderer/simple-basic-shapes/line.renderer.tsx
+++ b/src/pods/canvas/shape-renderer/simple-basic-shapes/line.renderer.tsx
@@ -1,0 +1,29 @@
+import { LineShape } from '@/common/components/front-basic-sapes';
+import { ShapeRendererProps } from '../model';
+import { ShapeModel } from '@/core/model';
+
+export const renderLine = (
+  shape: ShapeModel,
+  shapeRenderedProps: ShapeRendererProps
+) => {
+  const { handleSelected, shapeRefs, handleDragEnd, handleTransform } =
+    shapeRenderedProps;
+
+  return (
+    <LineShape
+      id={shape.id}
+      key={shape.id}
+      ref={shapeRefs.current[shape.id]}
+      x={shape.x}
+      y={shape.y}
+      name="shape"
+      width={shape.width}
+      height={shape.height}
+      draggable
+      onSelected={handleSelected}
+      onDragEnd={handleDragEnd(shape.id)}
+      onTransform={handleTransform}
+      onTransformEnd={handleTransform}
+    />
+  );
+};

--- a/src/pods/canvas/shape-renderer/simple-basic-shapes/line.renderer.tsx
+++ b/src/pods/canvas/shape-renderer/simple-basic-shapes/line.renderer.tsx
@@ -20,6 +20,7 @@ export const renderLine = (
       width={shape.width}
       height={shape.height}
       draggable
+      hasLateralTransformer={shape.hasLateralTransformer}
       onSelected={handleSelected}
       onDragEnd={handleDragEnd(shape.id)}
       onTransform={handleTransform}

--- a/src/pods/canvas/use-transform.hook.ts
+++ b/src/pods/canvas/use-transform.hook.ts
@@ -1,18 +1,35 @@
-import { Node, NodeConfig } from 'konva/lib/Node';
 import { Box } from 'konva/lib/shapes/Transformer';
-import { Coord, ShapeType, Size } from '@/core/model';
-
-interface TransFormSelectedInfo {
-  selectedShapeRef: React.MutableRefObject<Node<NodeConfig> | null>;
-  selectedShapeId: string;
-  selectedShapeType: ShapeType | null;
-}
+import { Coord, Size } from '@/core/model';
+import { useEffect } from 'react';
+import { useCanvasContext } from '@/core/providers';
 
 export const useTransform = (
-  updateShapeSizeAndPosition: (id: string, position: Coord, size: Size) => void,
-  transformSelectedInfo: TransFormSelectedInfo
+  updateShapeSizeAndPosition: (id: string, position: Coord, size: Size) => void
 ) => {
-  const { selectedShapeId, selectedShapeRef } = transformSelectedInfo;
+  const { selectedShapeId, selectedShapeRef, transformerRef } =
+    useCanvasContext().selectionInfo;
+
+  useEffect(() => {
+    const selectedShape = selectedShapeRef.current;
+    const transformer = transformerRef.current;
+    if (selectedShape && transformer) {
+      const hasLateralTransformer = selectedShape.attrs.hasLateralTransformer;
+      if (hasLateralTransformer) {
+        transformerRef.current.enabledAnchors(['middle-left', 'middle-right']);
+      } else {
+        transformerRef.current.enabledAnchors([
+          'top-left',
+          'top-center',
+          'top-right',
+          'middle-left',
+          'middle-right',
+          'bottom-left',
+          'bottom-center',
+          'bottom-right',
+        ]);
+      }
+    }
+  }, [selectedShapeId]);
 
   const handleTransform = () => {
     const node = selectedShapeRef.current;


### PR DESCRIPTION
Created Line Basic Shape. Closes #150 

I had to do some fixing, the transformer works badly for very small elements. I have created a 10 px transparent rectangle containing the line so it can work.

@brauliodiez I have a question here, should we change the drag "points" of the transformer for certain figures? For example, a line could only be extended to the sides, but not from the corners. 

Do you think it could be solved directly from the Hook of the transformer? I've made some approximations and it seems to work, but I'd have to get some info from the provider, I don't know if you want me to take a look at it. 
````
//useEffect
		if (transformerRef.current) {
			if (selectedShapeType === 'line') {
				transformerRef.current.enabledAnchors(['middle-left', 'middle-right']);
			} else {
				transformerRef.current.enabledAnchors([
					'top-left', 'top-center', 'top-right',
					'middle-left', 'middle-right',
					'bottom-left', 'bottom-center', 'bottom-right'
				]);
			}`
````
![CPT2408111654-575x390](https://github.com/user-attachments/assets/9823be71-b4e8-4b03-a254-559d9199c62f)

