### PR TITLE
Added `borderRadius` property

### DIFF
--- a/src/common/components/front-basic-sapes/postit-basic-shape.tsx
+++ b/src/common/components/front-basic-sapes/postit-basic-shape.tsx
@@ -3,6 +3,7 @@ import { forwardRef, useMemo } from 'react';
 import { ShapeProps } from '../front-components/shape.model';
 import { fitSizeToShapeSizeRestrictions } from '@/common/utils/shapes/shape-restrictions';
 import { Group, Rect, Text } from 'react-konva';
+import { INPUT_SHAPE } from '../front-components/shape.const';
 
 const postItShapeRestrictions: ShapeSizeRestrictions = {
   minWidth: 80,
@@ -58,6 +59,11 @@ export const PostItShape = forwardRef<any, ShapeProps>(
       [otherProps?.strokeStyle]
     );
 
+    const borderRadius = useMemo(() => {
+      const radius = Number(otherProps?.borderRadius);
+      return isNaN(radius) ? INPUT_SHAPE.DEFAULT_CORNER_RADIUS : radius;
+    }, [otherProps?.borderRadius]);
+
     return (
       <Group
         x={x}
@@ -74,7 +80,7 @@ export const PostItShape = forwardRef<any, ShapeProps>(
           y={10}
           width={postItWidth}
           height={restrictedHeight - 10}
-          cornerRadius={10}
+          cornerRadius={borderRadius}
           stroke={stroke}
           strokeWidth={2}
           dash={strokeStyle}

--- a/src/common/components/front-basic-sapes/rectangle-basic-shape.tsx
+++ b/src/common/components/front-basic-sapes/rectangle-basic-shape.tsx
@@ -3,6 +3,7 @@ import { forwardRef, useMemo } from 'react';
 import { ShapeProps } from '../front-components/shape.model';
 import { fitSizeToShapeSizeRestrictions } from '@/common/utils/shapes/shape-restrictions';
 import { Group, Rect } from 'react-konva';
+import { INPUT_SHAPE } from '../front-components/shape.const';
 
 const rectangleShapeRestrictions: ShapeSizeRestrictions = {
   minWidth: 10,
@@ -39,6 +40,11 @@ export const RectangleShape = forwardRef<any, ShapeProps>(
       [otherProps?.strokeStyle]
     );
 
+    const borderRadius = useMemo(() => {
+      const radius = Number(otherProps?.borderRadius);
+      return isNaN(radius) ? INPUT_SHAPE.DEFAULT_CORNER_RADIUS : radius;
+    }, [otherProps?.borderRadius]);
+
     return (
       <Group
         x={x}
@@ -58,7 +64,7 @@ export const RectangleShape = forwardRef<any, ShapeProps>(
           stroke={stroke}
           fill={fill}
           dash={strokeStyle}
-          cornerRadius={5}
+          cornerRadius={borderRadius}
         />
       </Group>
     );

--- a/src/common/components/front-components/button-shape.tsx
+++ b/src/common/components/front-components/button-shape.tsx
@@ -3,6 +3,7 @@ import { forwardRef, useMemo } from 'react';
 import { ShapeProps } from './shape.model';
 import { fitSizeToShapeSizeRestrictions } from '@/common/utils/shapes/shape-restrictions';
 import { Group, Rect, Text } from 'react-konva';
+import { INPUT_SHAPE } from './shape.const';
 
 const buttonShapeRestrictions: ShapeSizeRestrictions = {
   minWidth: 50,
@@ -44,6 +45,11 @@ export const ButtonShape = forwardRef<any, ShapeProps>(
       [otherProps?.strokeStyle]
     );
 
+    const borderRadius = useMemo(() => {
+      const radius = Number(otherProps?.borderRadius);
+      return isNaN(radius) ? INPUT_SHAPE.DEFAULT_CORNER_RADIUS : radius;
+    }, [otherProps?.borderRadius]);
+
     return (
       <Group
         x={x}
@@ -59,7 +65,7 @@ export const ButtonShape = forwardRef<any, ShapeProps>(
           y={0}
           width={restrictedWidth}
           height={restrictedHeight}
-          cornerRadius={6}
+          cornerRadius={borderRadius}
           stroke={stroke}
           dash={strokeStyle}
           strokeWidth={1.5}

--- a/src/common/components/front-components/combobox-shape.tsx
+++ b/src/common/components/front-components/combobox-shape.tsx
@@ -44,6 +44,24 @@ export const ComboBoxShape = forwardRef<any, ShapeProps>(
       [otherProps?.strokeStyle]
     );
 
+    const borderRadius = useMemo(() => {
+      const stringBorderRadius = otherProps?.borderRadius ?? '12';
+      return parseFloat(stringBorderRadius);
+    }, [otherProps?.borderRadius]);
+
+    const createPathWithRoundedCorners = (w: number, h: number, r: number) => {
+      return `M${r},0 
+              H${w - r} 
+              Q${w},0 ${w},${r} 
+              V${h - r} 
+              Q${w},${h} ${w - r},${h} 
+              H${r} 
+              Q0,${h} 0,${h - r} 
+              V${r} 
+              Q0,0 ${r},0 
+              Z`;
+    };
+
     return (
       <Group
         x={x}
@@ -54,9 +72,13 @@ export const ComboBoxShape = forwardRef<any, ShapeProps>(
         {...shapeProps}
         onClick={() => onSelected(id, 'combobox')}
       >
-        {/* Rectangle */}
+        {/* Rectangle with rounded corners */}
         <Path
-          data={`M1,1 H${width - 2} V${height - 2} H1 Z`}
+          data={createPathWithRoundedCorners(
+            restrictedWidth,
+            restrictedHeight,
+            borderRadius
+          )}
           stroke={stroke}
           strokeWidth={2}
           dash={strokeStyle}
@@ -64,26 +86,27 @@ export const ComboBoxShape = forwardRef<any, ShapeProps>(
         />
         {/* Polygon (Arrow), combo triangle dropdown */}
         <Path
-          data={`M${width - 30},${(height + 10) / 2 - 15} L${width - 10},${
-            (height + 10) / 2 - 15
-          } L${width - 20},${(height + 10) / 2}`}
+          data={`M${restrictedWidth - 30},${(restrictedHeight + 10) / 2 - 15} 
+                L${restrictedWidth - 10},${(restrictedHeight + 10) / 2 - 15} 
+                L${restrictedWidth - 20},${(restrictedHeight + 10) / 2}`}
           fill={stroke}
         />
         {/* Combo arrow vertical line separator */}
         <Path
-          data={`M${width - 40},1 L${width - 40},${height - 1}`}
+          data={`M${restrictedWidth - 40},1 
+                L${restrictedWidth - 40},${restrictedHeight - 1}`}
           stroke={stroke}
           strokeWidth={2}
           dash={strokeStyle}
         />
         <Text
           x={10}
-          y={(height - 25) / 2 + 5}
+          y={(restrictedHeight - 25) / 2 + 5}
           text={text}
           fontSize={20}
           fontFamily="Arial"
           fill={textColor}
-          width={width - 50}
+          width={restrictedWidth - 50}
           ellipsis={true}
           wrap="none"
         />

--- a/src/common/components/front-components/datepickerinput-shape.tsx
+++ b/src/common/components/front-components/datepickerinput-shape.tsx
@@ -3,6 +3,7 @@ import { forwardRef, useMemo } from 'react';
 import { ShapeProps } from './shape.model';
 import { fitSizeToShapeSizeRestrictions } from '@/common/utils/shapes/shape-restrictions';
 import { Group, Rect, Line } from 'react-konva';
+import { INPUT_SHAPE } from './shape.const';
 
 const datepickerInputShapeRestrictions: ShapeSizeRestrictions = {
   minWidth: 80,
@@ -44,6 +45,11 @@ export const DatepickerInputShape = forwardRef<any, ShapeProps>(
       [otherProps?.strokeStyle]
     );
 
+    const borderRadius = useMemo(() => {
+      const radius = Number(otherProps?.borderRadius);
+      return isNaN(radius) ? INPUT_SHAPE.DEFAULT_CORNER_RADIUS : radius;
+    }, [otherProps?.borderRadius]);
+
     return (
       <Group
         x={x}
@@ -60,7 +66,7 @@ export const DatepickerInputShape = forwardRef<any, ShapeProps>(
           y={0}
           width={restrictedWidth}
           height={restrictedHeight + 4}
-          cornerRadius={10}
+          cornerRadius={borderRadius}
           stroke={stroke}
           strokeWidth={2}
           dash={strokeStyle}

--- a/src/common/components/front-components/input-shape.tsx
+++ b/src/common/components/front-components/input-shape.tsx
@@ -45,6 +45,11 @@ export const InputShape = forwardRef<any, ShapeProps>(
       [otherProps?.strokeStyle]
     );
 
+    const borderRadius = useMemo(() => {
+      const radius = Number(otherProps?.borderRadius);
+      return isNaN(radius) ? INPUT_SHAPE.DEFAULT_CORNER_RADIUS : radius;
+    }, [otherProps?.borderRadius]);
+
     return (
       <Group
         x={x}
@@ -60,7 +65,7 @@ export const InputShape = forwardRef<any, ShapeProps>(
           y={0}
           width={restrictedWidth}
           height={restrictedHeight}
-          cornerRadius={INPUT_SHAPE.DEFAULT_CORNER_RADIUS}
+          cornerRadius={borderRadius}
           stroke={stroke}
           dash={strokeStyle}
           strokeWidth={INPUT_SHAPE.DEFAULT_STROKE_WIDTH}

--- a/src/common/components/front-components/listbox/listbox-shape.tsx
+++ b/src/common/components/front-components/listbox/listbox-shape.tsx
@@ -6,6 +6,7 @@ import {
   calculateDynamicContentSizeRestriction,
   mapListboxTextToItems,
 } from './listbox-shape.business';
+import { INPUT_SHAPE } from '../shape.const';
 
 const listboxShapeSizeRestrictions: ShapeSizeRestrictions = {
   minWidth: 75,
@@ -76,6 +77,11 @@ export const ListBoxShape = forwardRef<any, ListBoxShapeProps>(
       [otherProps?.strokeStyle]
     );
 
+    const borderRadius = useMemo(() => {
+      const radius = Number(otherProps?.borderRadius);
+      return isNaN(radius) ? INPUT_SHAPE.DEFAULT_CORNER_RADIUS : radius;
+    }, [otherProps?.borderRadius]);
+
     return (
       <Group
         x={x}
@@ -92,7 +98,7 @@ export const ListBoxShape = forwardRef<any, ListBoxShapeProps>(
           width={restrictedWidth + 20}
           height={restrictedHeight + 20}
           ref={rectRef}
-          cornerRadius={10}
+          cornerRadius={borderRadius}
           stroke={stroke}
           strokeWidth={2}
           dash={strokeStyle}

--- a/src/common/components/front-components/textarea-shape.tsx
+++ b/src/common/components/front-components/textarea-shape.tsx
@@ -3,6 +3,7 @@ import { forwardRef, useMemo } from 'react';
 import { ShapeProps } from './shape.model';
 import { fitSizeToShapeSizeRestrictions } from '@/common/utils/shapes/shape-restrictions';
 import { Group, Rect, Text } from 'react-konva';
+import { INPUT_SHAPE } from './shape.const';
 
 const textAreaShapeRestrictions: ShapeSizeRestrictions = {
   minWidth: 80,
@@ -44,6 +45,11 @@ export const TextAreaShape = forwardRef<any, ShapeProps>(
       [otherProps?.strokeStyle]
     );
 
+    const borderRadius = useMemo(() => {
+      const radius = Number(otherProps?.borderRadius);
+      return isNaN(radius) ? INPUT_SHAPE.DEFAULT_CORNER_RADIUS : radius;
+    }, [otherProps?.borderRadius]);
+
     return (
       <Group
         x={x}
@@ -59,7 +65,7 @@ export const TextAreaShape = forwardRef<any, ShapeProps>(
           y={0}
           width={restrictedWidth}
           height={restrictedHeight}
-          cornerRadius={5}
+          cornerRadius={borderRadius}
           stroke={stroke}
           strokeWidth={2}
           fill={fill}

--- a/src/common/components/front-components/timepickerinput-shape.tsx
+++ b/src/common/components/front-components/timepickerinput-shape.tsx
@@ -3,6 +3,7 @@ import { forwardRef, useMemo } from 'react';
 import { ShapeProps } from './shape.model';
 import { fitSizeToShapeSizeRestrictions } from '@/common/utils/shapes/shape-restrictions';
 import { Group, Rect, Text } from 'react-konva';
+import { INPUT_SHAPE } from './shape.const';
 
 const timepickerInputShapeRestrictions: ShapeSizeRestrictions = {
   minWidth: 100,
@@ -44,6 +45,11 @@ export const TimepickerInputShape = forwardRef<any, ShapeProps>(
       [otherProps?.strokeStyle]
     );
 
+    const borderRadius = useMemo(() => {
+      const radius = Number(otherProps?.borderRadius);
+      return isNaN(radius) ? INPUT_SHAPE.DEFAULT_CORNER_RADIUS : radius;
+    }, [otherProps?.borderRadius]);
+
     return (
       <Group
         x={x}
@@ -60,7 +66,7 @@ export const TimepickerInputShape = forwardRef<any, ShapeProps>(
           y={0}
           width={restrictedWidth}
           height={restrictedHeight}
-          cornerRadius={10}
+          cornerRadius={borderRadius}
           stroke={stroke}
           strokeWidth={2}
           dash={strokeStyle}

--- a/src/common/components/front-rich-components/horizontal-menu.tsx
+++ b/src/common/components/front-rich-components/horizontal-menu.tsx
@@ -3,6 +3,7 @@ import { ShapeSizeRestrictions } from '@/core/model';
 import { forwardRef, useMemo } from 'react';
 import { ShapeProps } from '../front-components/shape.model';
 import { fitSizeToShapeSizeRestrictions } from '@/common/utils/shapes/shape-restrictions';
+import { INPUT_SHAPE } from '../front-components/shape.const';
 
 const horizontalMenuShapeSizeRestrictions: ShapeSizeRestrictions = {
   minWidth: 75,
@@ -42,18 +43,26 @@ export const HorizontalMenu = forwardRef<any, ShapeProps>(
       () => otherProps?.textColor ?? 'black',
       [otherProps?.textColor]
     );
+
     const backgroundColor = useMemo(
       () => otherProps?.backgroundColor ?? 'white',
       [otherProps?.backgroundColor]
     );
+
     const strokeColor = useMemo(
       () => otherProps?.stroke ?? 'black',
       [otherProps?.stroke]
     );
+
     const strokeStyle = useMemo(
       () => otherProps?.strokeStyle ?? [],
       [otherProps?.strokeStyle]
     );
+
+    const borderRadius = useMemo(() => {
+      const radius = Number(otherProps?.borderRadius);
+      return isNaN(radius) ? INPUT_SHAPE.DEFAULT_CORNER_RADIUS : radius;
+    }, [otherProps?.borderRadius]);
 
     return (
       <Group
@@ -74,6 +83,7 @@ export const HorizontalMenu = forwardRef<any, ShapeProps>(
           strokeWidth={2}
           dash={strokeStyle}
           fill={backgroundColor}
+          cornerRadius={borderRadius}
         />
 
         {menuElements.map((e: string, index: number) => (

--- a/src/common/components/front-rich-components/modal/modal.tsx
+++ b/src/common/components/front-rich-components/modal/modal.tsx
@@ -40,16 +40,19 @@ export const Modal = forwardRef<any, ShapeProps>(
       () => otherProps?.textColor ?? '000000',
       [otherProps?.textColor]
     );
+
     const backgroundColor = useMemo(
       () => otherProps?.backgroundColor ?? '#00FFFF',
       [otherProps?.backgroundColor]
     );
-    const darkHeaderColor = darkenColor(backgroundColor, 40);
-    const darkButtonColor = darkenColor(backgroundColor, 60);
+
     const strokeColor = useMemo(
       () => otherProps?.stroke ?? '000000',
       [otherProps?.stroke]
     );
+
+    const darkHeaderColor = darkenColor(backgroundColor, 40);
+    const darkButtonColor = darkenColor(backgroundColor, 60);
 
     return (
       <Group

--- a/src/common/components/front-rich-components/vertical-menu/vertical-menu.tsx
+++ b/src/common/components/front-rich-components/vertical-menu/vertical-menu.tsx
@@ -6,6 +6,7 @@ import {
   calculateDynamicContentSizeRestriction,
   mapTextToOptions,
 } from './vertical-menu.business';
+import { INPUT_SHAPE } from '../../front-components/shape.const';
 
 const verticalMenuShapeSizeRestrictions: ShapeSizeRestrictions = {
   minWidth: 220,
@@ -84,6 +85,11 @@ export const VerticalMenuShape = forwardRef<any, VerticalMenuShapeProps>(
       [otherProps?.strokeStyle]
     );
 
+    const borderRadius = useMemo(() => {
+      const radius = Number(otherProps?.borderRadius);
+      return isNaN(radius) ? INPUT_SHAPE.DEFAULT_CORNER_RADIUS : radius;
+    }, [otherProps?.borderRadius]);
+
     return (
       <Group
         x={x}
@@ -103,6 +109,7 @@ export const VerticalMenuShape = forwardRef<any, VerticalMenuShapeProps>(
           strokeWidth={2}
           fill={fill}
           dash={strokeStyle}
+          cornerRadius={borderRadius}
         />
         {verticalMenuItems.map((option, index) => (
           <Group key={index}>

--- a/src/core/model/index.ts
+++ b/src/core/model/index.ts
@@ -147,6 +147,7 @@ export interface OtherProps {
   iconSize?: IconSize;
   imageSrc?: string;
   progress?: string;
+  borderRadius?: string;
 }
 
 export const BASE_ICONS_URL = '/icons/';

--- a/src/pods/canvas/canvas.model.ts
+++ b/src/pods/canvas/canvas.model.ts
@@ -356,15 +356,29 @@ export const generateDefaultOtherProps = (
         backgroundColor: INPUT_SHAPE.DEFAULT_FILL_BACKGROUND,
         textColor: INPUT_SHAPE.DEFAULT_FILL_TEXT,
         strokeStyle: [],
+        borderRadius: '12',
       };
     case 'button':
     case 'textarea':
-    case 'combobox':
     case 'listbox':
     case 'vertical-menu':
     case 'horizontal-menu':
     case 'datepickerinput':
     case 'timepickerinput':
+      return {
+        stroke: BASIC_SHAPE.DEFAULT_STROKE_COLOR,
+        backgroundColor: BASIC_SHAPE.DEFAULT_FILL_BACKGROUND,
+        textColor: BASIC_SHAPE.DEFAULT_FILL_TEXT,
+        strokeStyle: [],
+        borderRadius: '12',
+      };
+    case 'combobox':
+      return {
+        stroke: BASIC_SHAPE.DEFAULT_STROKE_COLOR,
+        backgroundColor: BASIC_SHAPE.DEFAULT_FILL_BACKGROUND,
+        textColor: BASIC_SHAPE.DEFAULT_FILL_TEXT,
+        strokeStyle: [],
+      };
     case 'modal':
       return {
         stroke: BASIC_SHAPE.DEFAULT_STROKE_COLOR,
@@ -384,8 +398,9 @@ export const generateDefaultOtherProps = (
         backgroundColor: '#FFFF99',
         textColor: '#000000',
         strokeStyle: [],
+        borderRadius: '12',
       };
-    case 'rectangle':
+
     case 'circle':
     case 'star':
     case 'diamond':
@@ -394,6 +409,13 @@ export const generateDefaultOtherProps = (
         stroke: '#000000',
         backgroundColor: '#ffffff',
         strokeStyle: [],
+      };
+    case 'rectangle':
+      return {
+        stroke: '#000000',
+        backgroundColor: '#ffffff',
+        strokeStyle: [],
+        borderRadius: '12',
       };
     case 'line':
       return {

--- a/src/pods/canvas/canvas.model.ts
+++ b/src/pods/canvas/canvas.model.ts
@@ -378,6 +378,7 @@ export const generateDefaultOtherProps = (
         backgroundColor: BASIC_SHAPE.DEFAULT_FILL_BACKGROUND,
         textColor: BASIC_SHAPE.DEFAULT_FILL_TEXT,
         strokeStyle: [],
+        borderRadius: '12',
       };
     case 'modal':
       return {

--- a/src/pods/properties/components/border-radius/border-radius.component.tsx
+++ b/src/pods/properties/components/border-radius/border-radius.component.tsx
@@ -1,0 +1,40 @@
+import classes from './border-radius.module.css';
+
+interface Props {
+  borderRadius: string | undefined;
+  label: string;
+  onChange: (borderRadius: string) => void;
+}
+
+export const BorderRadius: React.FC<Props> = props => {
+  const { label, borderRadius, onChange } = props;
+
+  return (
+    <div className={classes.container}>
+      <p>{label}</p>
+      <div className={classes.buttonsContainer}>
+        <button
+          onClick={() => onChange('0')}
+          className={`${classes.button} ${borderRadius === '0' ? classes.active : ''}`}
+          style={{ borderRadius: '0' }}
+        >
+          Sharp
+        </button>
+        <button
+          onClick={() => onChange('12')}
+          className={`${classes.button} ${borderRadius === '12' ? classes.active : ''}`}
+          style={{ borderRadius: '12' }}
+        >
+          Rounded
+        </button>
+        <button
+          onClick={() => onChange('30')}
+          className={`${classes.button} ${borderRadius === '30' ? classes.active : ''}`}
+          style={{ borderRadius: '30' }}
+        >
+          Smooth
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/pods/properties/components/border-radius/border-radius.component.tsx
+++ b/src/pods/properties/components/border-radius/border-radius.component.tsx
@@ -18,21 +18,63 @@ export const BorderRadius: React.FC<Props> = props => {
           className={`${classes.button} ${borderRadius === '0' ? classes.active : ''}`}
           style={{ borderRadius: '0' }}
         >
-          Sharp
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="1em"
+            height="1em"
+            viewBox="0 0 24 24"
+          >
+            <path
+              fill="none"
+              stroke="currentColor"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2"
+              d="M4 20V5a1 1 0 0 1 1-1h15"
+            />
+          </svg>
         </button>
         <button
           onClick={() => onChange('12')}
           className={`${classes.button} ${borderRadius === '12' ? classes.active : ''}`}
-          style={{ borderRadius: '12' }}
+          style={{ borderRadius: '0' }}
         >
-          Rounded
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="1em"
+            height="1em"
+            viewBox="0 0 24 24"
+          >
+            <path
+              fill="none"
+              stroke="currentColor"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2"
+              d="M4 20V10a6 6 0 0 1 6-6h10"
+            />
+          </svg>
         </button>
         <button
           onClick={() => onChange('30')}
           className={`${classes.button} ${borderRadius === '30' ? classes.active : ''}`}
-          style={{ borderRadius: '30' }}
+          style={{ borderRadius: '0' }}
         >
-          Smooth
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="1em"
+            height="1em"
+            viewBox="0 0 24 24"
+          >
+            <path
+              fill="none"
+              stroke="currentColor"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2"
+              d="M4 20v-5C4 8.925 8.925 4 15 4h5"
+            />
+          </svg>
         </button>
       </div>
     </div>

--- a/src/pods/properties/components/border-radius/border-radius.module.css
+++ b/src/pods/properties/components/border-radius/border-radius.module.css
@@ -1,0 +1,39 @@
+.container {
+  display: flex;
+  align-items: center;
+  gap: 1.5em;
+  padding: var(--space-xs) var(--space-md);
+  border-bottom: 1px solid var(--primary-300);
+}
+
+.buttonsContainer {
+  display: flex;
+  gap: 1em;
+  align-items: center;
+  margin-left: auto;
+}
+
+.button {
+  border: none;
+  color: var(--text-color);
+  background-color: inherit;
+  width: auto;
+  min-width: 80px;
+  font-size: var(--fs-xs);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.3s ease-in-out;
+  cursor: pointer;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+}
+
+.button:hover {
+  background-color: var(--primary-100);
+}
+
+.active {
+  background-color: var(--primary-200);
+  box-shadow: inset 0 2px 5px rgba(0, 0, 0, 0.2);
+  transform: translateY(2px);
+}

--- a/src/pods/properties/components/border-radius/border-radius.module.css
+++ b/src/pods/properties/components/border-radius/border-radius.module.css
@@ -18,7 +18,8 @@
   color: var(--text-color);
   background-color: inherit;
   width: auto;
-  min-width: 80px;
+  min-width: 30px;
+  border-radius: 10px;
   font-size: var(--fs-xs);
   display: flex;
   align-items: center;

--- a/src/pods/properties/components/border-radius/index.ts
+++ b/src/pods/properties/components/border-radius/index.ts
@@ -1,0 +1,1 @@
+export * from './border-radius.component';

--- a/src/pods/properties/components/index.ts
+++ b/src/pods/properties/components/index.ts
@@ -3,3 +3,4 @@ export * from './select-size';
 export * from './color-picker';
 export * from './icon-selector';
 export * from './progress';
+export * from './border-radius';

--- a/src/pods/properties/properties.pod.tsx
+++ b/src/pods/properties/properties.pod.tsx
@@ -3,7 +3,7 @@ import classes from './properties.pod.module.css';
 import { ZIndexOptions } from './components/zindex/zindex-option.component';
 import { ColorPicker } from './components/color-picker/color-picker.component';
 import { Checked } from './components/checked/checked.component';
-import { SelectSize, SelectIcon } from './components';
+import { SelectSize, SelectIcon, BorderRadius } from './components';
 import { StrokeStyle } from './components/stroke-style/stroke.style.component';
 import { Progress } from './components/progress/progress.component';
 
@@ -87,6 +87,15 @@ export const PropertiesPod = () => {
           progress={selectedShapeData?.otherProps?.progress}
           onChange={progress =>
             updateOtherPropsOnSelected('progress', progress)
+          }
+        />
+      )}
+      {selectedShapeData?.otherProps?.borderRadius && (
+        <BorderRadius
+          label="Border-radius"
+          borderRadius={selectedShapeData?.otherProps?.borderRadius}
+          onChange={borderRadius =>
+            updateOtherPropsOnSelected('borderRadius', borderRadius)
           }
         />
       )}


### PR DESCRIPTION
feat: Add border-radius property and implement selection buttons

- Added `borderRadius` property to component props.
- Updated the interface and relevant components to handle the new `borderRadius` property.
- Implemented the `borderRadius` property in relevant components, including `InputShape`.
- Created three buttons in the `BorderRadius` component to select between different border radius options: Sharp, Rounded, and Smooth.
- Adjusted styles to align buttons to the right of the container and enhance visual presentation.

Closes #223 