### PR TITLE
Feature/#288 add mountains placeholder to image

### DIFF
--- a/public/shapes/image.svg
+++ b/public/shapes/image.svg
@@ -1,10 +1,4 @@
-<svg width="200" height="200" xmlns="http://www.w3.org/2000/svg">
-    <!-- Cuadrado -->
-    <rect x="10" y="10" width="180" height="180" fill="none" stroke="black" stroke-width="2"/>
-
-    <!-- Línea diagonal de arriba izquierda a abajo derecha -->
-    <line x1="10" y1="10" x2="190" y2="190" stroke="black" stroke-width="2"/>
-
-    <!-- Línea diagonal de abajo izquierda a arriba derecha -->
-    <line x1="10" y1="190" x2="190" y2="10" stroke="black" stroke-width="2"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="1.2em" height="1.2em" viewBox="2 2 20 20">
+  <path fill="#D3D3D3" d="M5 5v14h14V5zm0-2h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2m3.5 7a1.5 1.5 0 1 0 0-3a1.5 1.5 0 0 0 0 3M7 14l2-2l2 2l3-3l3 3v3H7z"/>
 </svg>
+

--- a/src/common/components/front-basic-sapes/image-shape/components/no-image.component.tsx
+++ b/src/common/components/front-basic-sapes/image-shape/components/no-image.component.tsx
@@ -1,4 +1,5 @@
-import { Group, Rect, Text } from 'react-konva';
+import { Group, Text, Image as KonvaImage } from 'react-konva';
+import useImage from 'use-image';
 
 interface Props {
   width: number;
@@ -7,18 +8,11 @@ interface Props {
 
 export const NoImageSelected: React.FC<Props> = props => {
   const { width, height } = props;
+  const [image] = useImage('/shapes/image.svg');
 
   return (
     <Group x={0} y={0} width={width} height={height}>
-      <Rect
-        x={0}
-        y={0}
-        width={width}
-        height={height}
-        strokeWidth={2}
-        stroke="black"
-        fill="white"
-      />
+      <KonvaImage x={0} y={0} width={width} height={height} image={image} />
       <Text
         x={0}
         y={0}
@@ -30,6 +24,7 @@ export const NoImageSelected: React.FC<Props> = props => {
         align="center"
         ellipsis={true}
         verticalAlign="middle"
+        textDecoration="underline"
       />
     </Group>
   );

--- a/src/common/components/front-basic-sapes/image-shape/image-shape.tsx
+++ b/src/common/components/front-basic-sapes/image-shape/image-shape.tsx
@@ -37,7 +37,12 @@ export const ImageShape = forwardRef<any, ShapeProps>(
         imageRef.current.filters([]); // Remove filter
         imageRef.current.getLayer()?.batchDraw(); // Redraw
       }
-    }, [image, otherProps?.imageBlackAndWhite]);
+    }, [
+      image,
+      otherProps?.imageBlackAndWhite,
+      restrictedWidth,
+      restrictedHeight,
+    ]);
 
     return (
       <Group


### PR DESCRIPTION
Closes #288 

Added as a KonvaImage using useImage.

Also fix a bug, image was not resizing when grayscale filter was active. Updated useEffect of cache.