### PR TITLE
Feature/#342 deselecting shape cmd+click

### DIFF
--- a/src/core/providers/canvas/use-selection.hook.ts
+++ b/src/core/providers/canvas/use-selection.hook.ts
@@ -67,12 +67,24 @@ export const useSelection = (
       );
       setSelectedShapesIds(arrayIds);
     } else {
-      // Multiple selection, just push what is selected to the current selection
-      selectedShapesRefs.current = selectedShapesRefs.current.concat(
-        arrayIds.map(id => shapeRefs.current[id].current)
-      );
+      // Multiple selection, add or remove from current selection
+      const auxSelectedShapesIds = [...selectedShapesIds];
+      const auxSelectedShapesRefs = [...selectedShapesRefs.current];
+      const selectedShapeId = arrayIds[0];
 
-      setSelectedShapesIds(formerShapeIds => [...formerShapeIds, ...arrayIds]);
+      // If the shape is already selected, remove it
+      if (auxSelectedShapesIds.includes(selectedShapeId)) {
+        const index = auxSelectedShapesIds.indexOf(selectedShapeId);
+        auxSelectedShapesIds.splice(index, 1);
+        auxSelectedShapesRefs.splice(index, 1);
+      } else {
+        // Else add it to the selection
+        auxSelectedShapesIds.push(selectedShapeId);
+        auxSelectedShapesRefs.push(shapeRefs.current[selectedShapeId].current);
+      }
+
+      selectedShapesRefs.current = auxSelectedShapesRefs;
+      setSelectedShapesIds(auxSelectedShapesIds);
     }
 
     transformerRef?.current?.nodes(selectedShapesRefs.current);

--- a/src/pods/canvas/use-multiple-selection-shape.hook.tsx
+++ b/src/pods/canvas/use-multiple-selection-shape.hook.tsx
@@ -3,14 +3,10 @@ import { SelectionInfo } from '@/core/providers/canvas/canvas.model';
 import Konva from 'konva';
 import { useState } from 'react';
 import { SelectionRect } from './canvas.model';
-import {
-  findFirstShapeInCoords,
-  getSelectedShapesFromSelectionRect,
-} from './use-multiple-selection.business';
+import { getSelectedShapesFromSelectionRect } from './use-multiple-selection.business';
 import { getTransformerBoxAndCoords } from './transformer.utils';
 import { calculateScaledCoordsFromCanvasDivCoordinatesNoScroll } from './canvas.util';
 import { Stage } from 'konva/lib/Stage';
-import { isUserDoingMultipleSelectionUsingCtrlOrCmdKey } from '@/common/utils/shapes';
 
 // There's a bug here: if you make a multiple selectin and start dragging
 // inside the selection but on a blank area it won't drag the selection

--- a/src/pods/canvas/use-multiple-selection-shape.hook.tsx
+++ b/src/pods/canvas/use-multiple-selection-shape.hook.tsx
@@ -101,6 +101,7 @@ export const useMultipleSelectionShapeHook = (
       return;
     }
 
+    /*
     const shape = findFirstShapeInCoords(shapes, mousePointerStageBasedCoord);
 
     // If you are not dragging, but you click on a shape you should select that shape
@@ -115,6 +116,7 @@ export const useMultipleSelectionShapeHook = (
       );
       return;
     }
+		*/
 
     selectionInfo.handleClearSelection(e);
     if (e.target !== e.target.getStage()) {


### PR DESCRIPTION
Look @brauliodiez handleSelected was being called twice. 

1. From src/pods/canvas/use-multiple-selection-shape.hook.tsx 
2. And  [src/common/components/shapes/use-shape-selection.hook.ts](src/common/components/shapes/use-shape-selection.hook.ts)

To make this works i commented the first one, i need some feedback about this. Currently working nice.