### PR TITLE
add unit test for mapTextToSections function

### DIFF
--- a/src/common/components/front-rich-components/accordion/accordion.business.spec.ts
+++ b/src/common/components/front-rich-components/accordion/accordion.business.spec.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { mapTextToSections } from './accordion.business';
+
+describe('mapTextToSections', () => {
+  it('should return default sections when text is empty', () => {
+    const emptyText = '';
+
+    const result = mapTextToSections(emptyText);
+
+    expect(result).toEqual({
+      sections: ['Section A', 'Section B'],
+      selectedSectionIndex: 0,
+    });
+  });
+
+  it('should return 1 section and selectedSectionIndex = 0 when text has 1 section', () => {
+    const singleSectionText = 'Section A';
+
+    const result = mapTextToSections(singleSectionText);
+
+    expect(result).toEqual({
+      sections: ['Section A'],
+      selectedSectionIndex: 0,
+    });
+  });
+
+  it('should return 2 sections and selectedSectionIndex = 1 when second section starts with [*]', () => {
+    const twoSectionsText = 'Section A\n[*]Section B';
+
+    const result = mapTextToSections(twoSectionsText);
+
+    expect(result).toEqual({
+      sections: ['Section A', 'Section B'],
+      selectedSectionIndex: 1,
+    });
+  });
+
+  it('should return 2 sections and selectedSectionIndex = 0 when no section starts with [*]', () => {
+    const twoSectionsText = 'Section A\nSection B';
+
+    const result = mapTextToSections(twoSectionsText);
+
+    expect(result).toEqual({
+      sections: ['Section A', 'Section B'],
+      selectedSectionIndex: 0,
+    });
+  });
+
+  it('should pick the first section with [*] and remove [*] from all sections', () => {
+    const multipleSelectedSectionsText =
+      '[*]Section A\n[*]Section B\n[*]Section C';
+
+    const result = mapTextToSections(multipleSelectedSectionsText);
+
+    expect(result).toEqual({
+      sections: ['Section A', 'Section B', 'Section C'],
+      selectedSectionIndex: 0,
+    });
+  });
+
+  it('should handle sections with special characters', () => {
+    const textWithSpecialChars = 'Section @A!\n[*]Section #B$';
+
+    const result = mapTextToSections(textWithSpecialChars);
+
+    expect(result).toEqual({
+      sections: ['Section @A!', 'Section #B$'],
+      selectedSectionIndex: 1,
+    });
+  });
+
+  it('should select the first marked section and remove [*] from all when multiple sections have [*]', () => {
+    const multipleSelectedText =
+      'Section A\n[*]Section B\nSection C\n[*]Section D';
+
+    const result = mapTextToSections(multipleSelectedText);
+
+    expect(result).toEqual({
+      sections: ['Section A', 'Section B', 'Section C', 'Section D'],
+      selectedSectionIndex: 1,
+    });
+  });
+});

--- a/src/common/components/front-rich-components/accordion/accordion.business.ts
+++ b/src/common/components/front-rich-components/accordion/accordion.business.ts
@@ -1,8 +1,6 @@
 import { fitSizeToShapeSizeRestrictions } from '@/common/utils/shapes/shape-restrictions';
 import { ShapeSizeRestrictions } from '@/core/model';
 
-// TODO: Add unit tests #169
-
 interface SizeInfo {
   width: number;
   height: number;
@@ -42,13 +40,6 @@ interface SectionsInfo {
   selectedSectionIndex: number;
 }
 
-// TODO: Add Unit tests
-// case 1 if text is empty just show default sections
-// case 2 if text has 1 section, then show 1 section and selectedSectionIndex = 0
-// case 3 if text has 2 sections, and section to starts with [*] then show 2 sections and selectedSectionIndex = 1, and section with removed [*]
-// case 4 if text has 2 sections, and no section to starts with [*] then show 2 sections and selectedSectionIndex = 0, and section with removed [*]
-// ...
-// If there are more than one section selected, pick the first one and remove the [*] from all of them
 export const mapTextToSections = (text: string): SectionsInfo => {
   if (!text) {
     return {


### PR DESCRIPTION
- Add tests for the default sections when input is empty
- Add test for handling a single section in the text
- Add test for two sections, where one starts with [*] (marked as selected)
- Add test for multiple sections without any marked [*]
- Ensure only the first section marked with [*] is selected when multiple are marked
- Handle edge cases: special characters

Closes #169 