### PR TITLE
#427 fix bug on paragraph component

### DIFF
--- a/src/common/components/mock-components/front-text-components/paragraph-text-shape.tsx
+++ b/src/common/components/mock-components/front-text-components/paragraph-text-shape.tsx
@@ -8,12 +8,12 @@ import { useShapeProps } from '../../shapes/use-shape-props.hook';
 import { useGroupShapeProps } from '../mock-components.utils';
 
 const paragraphSizeRestrictions: ShapeSizeRestrictions = {
-  minWidth: 300,
-  minHeight: 100,
+  minWidth: 200,
+  minHeight: 70,
   maxWidth: -1,
   maxHeight: -1,
   defaultWidth: 420,
-  defaultHeight: 125,
+  defaultHeight: 130,
 };
 
 export const getParagraphSizeRestrictions = (): ShapeSizeRestrictions =>
@@ -61,9 +61,7 @@ export const ParagraphShape = forwardRef<any, ShapeProps>((props, ref) => {
         fontSize={14}
         fill={textColor}
         align="left"
-        verticalAlign="middle"
         ellipsis={true}
-        wrap="none"
       />
     </Group>
   );


### PR DESCRIPTION
now the text takes up all the available space.

Closes #427 