### PR TITLE
Feature/#408 qa multiple selection unselect

### DIFF
--- a/e2e/helpers/konva-testing.helpers.ts
+++ b/e2e/helpers/konva-testing.helpers.ts
@@ -2,6 +2,7 @@ import { Page } from '@playwright/test';
 import { Layer } from 'konva/lib/Layer';
 import { Shape } from 'konva/lib/Shape';
 import { Group } from 'konva/lib/Group';
+import { E2E_CanvasItemKeyAttrs } from './types/e2e-types';
 
 const getLayer = async (page: Page): Promise<Layer> =>
   await page.evaluate(() => {
@@ -58,4 +59,47 @@ export const getTransformer = async (page: Page): Promise<any> => {
     );
   });
   return transformer;
+};
+
+export const getWithinCanvasItemList = async (
+  page: Page
+): Promise<Group['attrs'][]> => {
+  const items = await page.evaluate(() => {
+    return window.__TESTING_KONVA_LAYER__.find(
+      (c: any) => c.getType('Group') && (c.attrs['data-id'] as Group)
+    );
+  });
+  return items.map(it => it.attrs);
+};
+
+export const clickOnCanvasItem = async (
+  page: Page,
+  item: E2E_CanvasItemKeyAttrs
+) => {
+  const { x, y } = item;
+  const canvasWindowPos = await page.locator('canvas').boundingBox();
+  if (!canvasWindowPos) throw new Error('Canvas is not loaded on ui');
+  await page.mouse.move(
+    canvasWindowPos?.x + x + 20,
+    canvasWindowPos?.y + y + 20
+  );
+
+  await page.mouse.down();
+  await page.mouse.up();
+
+  return item;
+};
+
+export const ctrlClickOverCanvasItems = async (
+  page: Page,
+  itemList: E2E_CanvasItemKeyAttrs[]
+) => {
+  if (!itemList.length)
+    throw new Error('Please, add an array with at least one canvas Item');
+  // NOTE: The keyboard entry 'ControlOrMeta' is the way to simulate both 'Ctrl' or 'Command' key
+  await page.keyboard.down('ControlOrMeta');
+  for (const item of itemList) {
+    await clickOnCanvasItem(page, item);
+  }
+  await page.keyboard.up('ControlOrMeta');
 };

--- a/e2e/helpers/position.helpers.ts
+++ b/e2e/helpers/position.helpers.ts
@@ -37,6 +37,7 @@ export const addComponentsToCanvas = async (
 
   for await (const [index, c] of components.entries()) {
     const component = page.getByAltText(c, { exact: true });
+    await component.scrollIntoViewIfNeeded();
     const position = await getLocatorPosition(component);
 
     const targetPosition = (

--- a/e2e/helpers/types/e2e-types.d.ts
+++ b/e2e/helpers/types/e2e-types.d.ts
@@ -1,0 +1,8 @@
+export interface E2E_CanvasItemKeyAttrs {
+  x: number;
+  y: number;
+  ['data-id']: string;
+  width: number;
+  height: number;
+  shapeType: string;
+}

--- a/e2e/selection/multiple-selection.spec.ts
+++ b/e2e/selection/multiple-selection.spec.ts
@@ -1,5 +1,11 @@
 import { test, expect } from '@playwright/test';
-import { dragAndDrop, addComponentsToCanvas, getTransformer } from '../helpers';
+import {
+  dragAndDrop,
+  addComponentsToCanvas,
+  getTransformer,
+  getWithinCanvasItemList,
+  ctrlClickOverCanvasItems,
+} from '../helpers';
 
 test('Should perform multiple selection when dragging and dropping over multiple components in the canvas', async ({
   page,
@@ -45,4 +51,27 @@ test('Should deselect all previously selected items when clicking on an empty po
   //Assert
   const updatedSelectedItems = await getTransformer(page);
   expect(updatedSelectedItems._nodes.length).toEqual(0);
+});
+
+test('Should add some in-canvas-items to the current selection, by clicking on them, while pressing the CTRL / CMD keyboard.', async ({
+  page,
+}) => {
+  await page.goto('');
+
+  //Drag and drop component to canvas
+  const componentsAtCanvas = ['Input', 'Button', 'Textarea', 'Combobox'];
+  await addComponentsToCanvas(page, componentsAtCanvas);
+  const insideCanvasItemList = await getWithinCanvasItemList(page);
+
+  //Assert no elements at current selection
+  const selectedItems = await getTransformer(page);
+  expect(selectedItems._nodes.length).toEqual(1);
+
+  // Add 2 canvas items to current selection
+  const itemsToBeSelected = insideCanvasItemList.slice(1, 3);
+  await ctrlClickOverCanvasItems(page, itemsToBeSelected);
+
+  //Assert the quantity of selected-items
+  const currentSelection = await getTransformer(page);
+  expect(currentSelection._nodes.length).toEqual(3);
 });

--- a/e2e/selection/multiple-selection.spec.ts
+++ b/e2e/selection/multiple-selection.spec.ts
@@ -20,3 +20,29 @@ test('Should perform multiple selection when dragging and dropping over multiple
   const selectedItems = await getTransformer(page);
   expect(selectedItems._nodes.length).toEqual(3);
 });
+
+test('Should deselect all previously selected items when clicking on an empty point on the canvas', async ({
+  page,
+}) => {
+  await page.goto('');
+
+  //Drag and drop component to canvas
+  const componentsAtCanvas = ['Input', 'Input', 'Icon', 'Label'];
+  await addComponentsToCanvas(page, componentsAtCanvas);
+
+  //Click Away
+  await page.mouse.click(800, 130);
+
+  //Perform items selection by drag and drop
+  await dragAndDrop(page, { x: 260, y: 130 }, { x: 1000, y: 550 });
+
+  //Assert
+  const selectedItems = await getTransformer(page);
+  expect(selectedItems._nodes.length).toEqual(3);
+
+  //Click Away
+  await page.mouse.click(800, 130);
+  //Assert
+  const updatedSelectedItems = await getTransformer(page);
+  expect(updatedSelectedItems._nodes.length).toEqual(0);
+});


### PR DESCRIPTION
⚠️ This PR contains another merged qa-issue-branch, which is associated with tests of the ‘multiple selection’ family:
[Feature/](https://github.com/Lemoncode/quickmock/commit/1de2fa80341d628468b4aef746e3f875bf4f56d8)https://github.com/Lemoncode/quickmock/issues/406 [qa test multiple selection using ctrl or cmd](https://github.com/Lemoncode/quickmock/commit/1de2fa80341d628468b4aef746e3f875bf4f56d8)

Note:
There are some util methods included in this commits  that can be helpful in other QA E2E issues/cases:
- _getWithinCanvasItemList_
- _clickOnCanvasItem_
-  _ctrlClickOverCanvasItems_


closes #406
closes #408 