### PR TITLE
adjust small text component min width

### DIFF
--- a/src/common/components/mock-components/front-text-components/smalltext-shape.tsx
+++ b/src/common/components/mock-components/front-text-components/smalltext-shape.tsx
@@ -8,7 +8,7 @@ import { BASIC_SHAPE } from '../front-components/shape.const';
 import { useGroupShapeProps } from '../mock-components.utils';
 
 const smalltextSizeRestrictions: ShapeSizeRestrictions = {
-  minWidth: 150,
+  minWidth: 40,
   minHeight: 20,
   maxWidth: -1,
   maxHeight: -1,


### PR DESCRIPTION
I've changed min-width to a minimum of 40, to take into account cases like single letters or numbers in menus or lists:
![small-text-min-width-Captura de pantalla 2024-10-17 183134](https://github.com/user-attachments/assets/1e72d242-a4db-4fa8-9e22-b048c91d7ce4)

closes #447 