### PR TITLE
Add option to stroke style none

### DIFF
--- a/src/pods/properties/components/stroke-style/stroke.style.component.tsx
+++ b/src/pods/properties/components/stroke-style/stroke.style.component.tsx
@@ -31,6 +31,7 @@ export const StrokeStyle: React.FC<Props> = props => {
         <option value="10,10">- - - -</option>
         <option value="10,5,2,5">-.-.-.-</option>
         <option value="2,5">........</option>
+        <option value="0,1">None</option>
       </select>
     </div>
   );


### PR DESCRIPTION
Keep in mind that in Basic shapes, both the Horizontal Line and the Vertical Line, if we set the stroke style to none it will no longer be seen although the component is still there.

Closes #492 