### PR TITLE
add rename thumb page

### DIFF
--- a/e2e/inline-edit/rename-thumb-page.spec.ts
+++ b/e2e/inline-edit/rename-thumb-page.spec.ts
@@ -15,10 +15,10 @@ test('rename-thumb-page-through-direct-edit-and-context-menu', async ({
   const newTextContent = 'Change the name';
   await input.fill(newTextContent);
   await page.keyboard.press('Enter');
-  const renamedPage = page.getByText(newTextContent);
+  const renamedPage = page.getByText(newTextContent, { exact: true });
   await expect(renamedPage).toBeVisible();
 
-  const siblingElement = page.getByText('Change the name');
+  const siblingElement = page.getByText('Change the name', { exact: true });
   const divThumb = siblingElement.locator('..');
   await divThumb.click({ button: 'right' });
   await page.getByText('Rename').click();
@@ -27,6 +27,8 @@ test('rename-thumb-page-through-direct-edit-and-context-menu', async ({
   await expect(input).toBeVisible();
   await input.fill(secondNewTextContent);
   await page.keyboard.press('Enter');
-  const secondRenamedPage = page.getByText(secondNewTextContent);
+  const secondRenamedPage = page.getByText(secondNewTextContent, {
+    exact: true,
+  });
   await expect(secondRenamedPage).toBeVisible();
 });

--- a/e2e/inline-edit/rename-thumb-page.spec.ts
+++ b/e2e/inline-edit/rename-thumb-page.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test';
+
+test('rename-thumb-page-through-direct-edit-and-context-menu', async ({
+  page,
+}) => {
+  await page.goto('');
+
+  await page.getByText('Pages').click();
+  const thumb = page.getByText('Page 1');
+  await expect(thumb).toBeVisible();
+  await expect(thumb).toHaveText('Page 1');
+
+  await thumb.dblclick();
+  const input = page.getByRole('textbox');
+  const newTextContent = 'Change the name';
+  await input.fill(newTextContent);
+  await page.keyboard.press('Enter');
+  const renamedPage = page.getByText(newTextContent);
+  await expect(renamedPage).toBeVisible();
+
+  const siblingElement = page.getByText('Change the name');
+  const divThumb = siblingElement.locator('..');
+  await divThumb.click({ button: 'right' });
+  await page.getByText('Rename').click();
+
+  const secondNewTextContent = 'Other name';
+  await expect(input).toBeVisible();
+  await input.fill(secondNewTextContent);
+  await page.keyboard.press('Enter');
+  const secondRenamedPage = page.getByText(secondNewTextContent);
+  await expect(secondRenamedPage).toBeVisible();
+});

--- a/e2e/inline-edit/rename-thumb-page.spec.ts
+++ b/e2e/inline-edit/rename-thumb-page.spec.ts
@@ -6,7 +6,7 @@ test('rename-thumb-page-through-direct-edit-and-context-menu', async ({
   await page.goto('');
 
   await page.getByText('Pages').click();
-  const thumb = page.getByText('Page 1');
+  const thumb = page.getByText('Page 1', { exact: true });
   await expect(thumb).toBeVisible();
   await expect(thumb).toHaveText('Page 1');
 


### PR DESCRIPTION
add functionality to rename thumbnail pages via direct edit and context menu

- Implemented e2e test for renaming a thumbnail page.
- Verified renaming using direct double-click edit.
- Added context menu interaction to rename pages.
- Ensured renamed pages are correctly updated and visible in the UI.

Closes #550 