### PR TITLE
feature/#543 verify visibility of thumb page, chevron, and add new page button

### DIFF
--- a/e2e/inline-edit/visible-thumb-page.spec.ts
+++ b/e2e/inline-edit/visible-thumb-page.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test';
+
+test('verifies visibility of thumb page, chevron and add new page button', async ({
+  page,
+}) => {
+  await page.goto('');
+
+  await page.getByText('Pages').click();
+
+  const siblingElement = page.getByText('Page 1', { exact: true });
+  const thumb = siblingElement.locator('..');
+  await expect(thumb).toBeVisible();
+
+  const svgElement = thumb.locator('span > svg');
+  await expect(svgElement).toBeVisible();
+
+  const addButton = page.getByRole('button', { name: 'add new page' });
+  await expect(addButton).toBeVisible();
+});


### PR DESCRIPTION
- Ensures the thumb page is visible in the DOM
- Confirms the chevron (SVG element within the thumb page) is rendered and visible
- Validates the visibility of the "add new page" button with the appropriate accessible label

Closes #543 