### PR TITLE
Add new CanvasProvider state to manage the opening of the ThumbsPagesPod accordion

### DIFF
--- a/src/core/local-disk/use-local-disk.hook.ts
+++ b/src/core/local-disk/use-local-disk.hook.ts
@@ -13,7 +13,7 @@ const DEFAULT_FILE_EXTENSION = 'qm';
 const DEFAULT_EXTENSION_DESCRIPTION = 'quick mock';
 
 export const useLocalDisk = () => {
-  const { fullDocument, loadDocument, fileName, setFileName } =
+  const { fullDocument, loadDocument, fileName, setFileName, setIsFileLoaded } =
     useCanvasContext();
 
   const serializeShapes = (): string => {
@@ -72,6 +72,7 @@ export const useLocalDisk = () => {
       }
     };
     reader.readAsText(file);
+    setIsFileLoaded(true);
   };
 
   const handleLoad = () => {

--- a/src/core/providers/canvas/canvas.model.ts
+++ b/src/core/providers/canvas/canvas.model.ts
@@ -110,4 +110,6 @@ export interface CanvasContextModel {
   setIsThumbnailContextMenuVisible: React.Dispatch<
     React.SetStateAction<boolean>
   >;
+  isFileLoaded: boolean;
+  setIsFileLoaded: React.Dispatch<React.SetStateAction<boolean>>;
 }

--- a/src/core/providers/canvas/canvas.provider.tsx
+++ b/src/core/providers/canvas/canvas.provider.tsx
@@ -25,6 +25,7 @@ export const CanvasProvider: React.FC<Props> = props => {
   const [fileName, setFileName] = React.useState<string>('');
   const [isThumbnailContextMenuVisible, setIsThumbnailContextMenuVisible] =
     React.useState(false);
+  const [isFileLoaded, setIsFileLoaded] = React.useState(false);
 
   const {
     addSnapshot,
@@ -331,6 +332,8 @@ export const CanvasProvider: React.FC<Props> = props => {
         activePageIndex: document.activePageIndex,
         isThumbnailContextMenuVisible,
         setIsThumbnailContextMenuVisible,
+        isFileLoaded,
+        setIsFileLoaded,
       }}
     >
       {children}

--- a/src/scenes/main.scene.tsx
+++ b/src/scenes/main.scene.tsx
@@ -14,10 +14,14 @@ import { PropertiesPod } from '@/pods/properties';
 import { FooterPod } from '@/pods/footer/footer.pod';
 import { ThumbPagesPod } from '@/pods/thumb-pages';
 import { useAccordionSectionVisibility } from './accordion-section-visibility.hook';
+import { useCanvasContext } from '@/core/providers';
 
 export const MainScene = () => {
   const { isThumbPagesPodOpen, thumbPagesPodRef } =
     useAccordionSectionVisibility();
+
+  const { isFileLoaded } = useCanvasContext();
+  const forceOpenThumbsPages = isFileLoaded && { open: true };
 
   return (
     <MainLayout>
@@ -27,6 +31,7 @@ export const MainScene = () => {
           className={classes.container}
           name="toolsLeft"
           ref={thumbPagesPodRef}
+          {...forceOpenThumbsPages}
         >
           <summary className={classes.title}>Pages</summary>
           <ThumbPagesPod isVisible={isThumbPagesPodOpen} />


### PR DESCRIPTION
When the user load a saved file, the ThumbsPagesPod accordion is open by default to improve the User Experience 

_There is no issue related_ 