### PR TITLE
Feature/#586 ensure paste in visibile place in canvas

### DIFF
--- a/src/core/providers/canvas/canvas.model.ts
+++ b/src/core/providers/canvas/canvas.model.ts
@@ -122,6 +122,8 @@ export interface CanvasContextModel {
   setCanvasSize: (canvasDimensions: CanvasSize) => void;
   customColors: (string | null)[];
   updateColorSlot: (color: string, index: number) => void;
+  dropRef: React.MutableRefObject<HTMLDivElement | null>;
+  setDropRef: (dropRef: React.MutableRefObject<HTMLDivElement | null>) => void;
 }
 
 export const APP_CONSTANTS = {

--- a/src/core/providers/canvas/canvas.provider.tsx
+++ b/src/core/providers/canvas/canvas.provider.tsx
@@ -183,11 +183,16 @@ export const CanvasProvider: React.FC<Props> = props => {
     });
   };
 
+  const [dropRef, setDropRef] = React.useState<
+    React.MutableRefObject<HTMLDivElement | null>
+  >(React.useRef<HTMLDivElement>(null));
+
   const { copyShapeToClipboard, pasteShapeFromClipboard, canCopy, canPaste } =
     useClipboard(
       pasteShapes,
       document.pages[document.activePageIndex].shapes,
-      selectionInfo
+      selectionInfo,
+      dropRef
     );
 
   const createNewFullDocument = () => {
@@ -362,6 +367,8 @@ export const CanvasProvider: React.FC<Props> = props => {
         setCanvasSize: setCanvasSize,
         customColors,
         updateColorSlot,
+        dropRef,
+        setDropRef,
       }}
     >
       {children}

--- a/src/core/providers/canvas/use-clipboard.hook.tsx
+++ b/src/core/providers/canvas/use-clipboard.hook.tsx
@@ -10,7 +10,8 @@ import {
 export const useClipboard = (
   pasteShapes: (shapes: ShapeModel[]) => void,
   shapes: ShapeModel[],
-  selectionInfo: { selectedShapesIds: string[] | null }
+  selectionInfo: { selectedShapesIds: string[] | null },
+  dropRef: React.MutableRefObject<HTMLDivElement | null>
 ) => {
   const [clipboardShape, setClipboardShape] = useState<ShapeModel[] | null>(
     null
@@ -34,7 +35,7 @@ export const useClipboard = (
     if (clipboardShapesRef.current) {
       const newShapes: ShapeModel[] = cloneShapes(clipboardShapesRef.current);
       validateShapes(newShapes);
-      adjustShapesPosition(newShapes, copyCount.current);
+      adjustShapesPosition(newShapes, copyCount.current, dropRef);
       pasteShapes(newShapes);
       copyCount.current++;
     }

--- a/src/pods/canvas/canvas.pod.tsx
+++ b/src/pods/canvas/canvas.pod.tsx
@@ -30,6 +30,7 @@ export const CanvasPod = () => {
     updateShapePosition,
     stageRef,
     canvasSize,
+    setDropRef,
   } = useCanvasContext();
 
   const {
@@ -52,6 +53,9 @@ export const CanvasPod = () => {
 
   const { isDraggedOver, dropRef } = useDropShape();
   useMonitorShape(dropRef, addNewShapeAndSetSelected);
+  useEffect(() => {
+    if (dropRef.current) setDropRef(dropRef);
+  }, [dropRef, setDropRef]);
 
   const getSelectedShapeKonvaId = (): string[] => {
     let result: string[] = [];

--- a/src/pods/canvas/clipboard.utils.ts
+++ b/src/pods/canvas/clipboard.utils.ts
@@ -1,6 +1,12 @@
 import cloneDeep from 'lodash.clonedeep';
 import { ShapeModel } from '@/core/model';
 import invariant from 'tiny-invariant';
+import { getScrollFromDiv } from './canvas.util';
+
+interface PositionScroll {
+  x: number;
+  y: number;
+}
 
 export const findShapesById = (
   shapeIds: string[],
@@ -17,12 +23,26 @@ export const cloneShape = (shape: ShapeModel): ShapeModel => {
   return cloneDeep(shape);
 };
 
-export const adjustShapesPosition = (shapes: ShapeModel[], copyCount: number) =>
-  shapes.map(shape => adjustShapePosition(shape, copyCount));
+export const adjustShapesPosition = (
+  shapes: ShapeModel[],
+  copyCount: number,
+  dropRef: React.MutableRefObject<HTMLDivElement | null>
+) => {
+  const { scrollLeft, scrollTop } = getScrollFromDiv(
+    dropRef as unknown as React.MutableRefObject<HTMLDivElement>
+  );
+  shapes.map(shape =>
+    adjustShapePosition(shape, copyCount, { x: scrollLeft, y: scrollTop })
+  );
+};
 
-export const adjustShapePosition = (shape: ShapeModel, copyCount: number) => {
-  shape.x += 20 * copyCount;
-  shape.y += 20 * copyCount;
+export const adjustShapePosition = (
+  shape: ShapeModel,
+  copyCount: number,
+  position: PositionScroll
+) => {
+  shape.x += 20 * copyCount + position.x;
+  shape.y += 20 * copyCount + position.y;
 };
 
 export const validateShapes = (shapes: ShapeModel[]) => {

--- a/src/pods/canvas/clipboard.utils.ts
+++ b/src/pods/canvas/clipboard.utils.ts
@@ -41,8 +41,8 @@ export const adjustShapePosition = (
   copyCount: number,
   position: PositionScroll
 ) => {
-  shape.x += 20 * copyCount + position.x;
-  shape.y += 20 * copyCount + position.y;
+  shape.x = 20 * copyCount + position.x;
+  shape.y = 20 * copyCount + position.y;
 };
 
 export const validateShapes = (shapes: ShapeModel[]) => {


### PR DESCRIPTION

**Description:**
This feature ensures that when shapes are pasted into the canvas, they are automatically positioned in a visible location, considering the scroll position. Key changes include:

- Introduction of the `dropRef` reference to track the scroll position of the canvas container.
- Modification of the `adjustShapesPosition` logic to calculate the paste position based on the current scroll offset.
- Removed the use of `+=` in the `adjustShapePosition` logic to prevent excessive coordinate increments after multiple pastes.
- Ensuring newly pasted shapes are correctly positioned by incorporating `scrollLeft` and `scrollTop` coordinates.