### PR TITLE
feat: add Shift + Click support for multi-selection #668

### DIFF
--- a/src/common/utils/shapes/on-click-keyboard.ts
+++ b/src/common/utils/shapes/on-click-keyboard.ts
@@ -3,8 +3,9 @@ import Konva from 'konva';
 export const isUserDoingMultipleSelectionUsingCtrlOrCmdKey = (
   e: Konva.KonvaEventObject<MouseEvent> | Konva.KonvaEventObject<TouchEvent>
 ) => {
-  // Ctrl in Windows o Cmd en Mac
-  const isCtrlOrCmdPressed = e.evt.ctrlKey || e.evt.metaKey;
+  // Check if Ctrl (Windows), Cmd (Mac), or Shift is pressed
+  const isCtrlOrCmdOrShiftPressed =
+    e.evt.ctrlKey || e.evt.metaKey || e.evt.shiftKey;
 
-  return isCtrlOrCmdPressed;
+  return isCtrlOrCmdOrShiftPressed;
 };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,4 +26,8 @@ export default defineConfig({
       '@': fileURLToPath(new URL('./src', import.meta.url)),
     },
   },
+  server: {
+    port: 5173, // Usa el mismo puerto que te muestra la terminal
+    open: true, // Esto abrirá el navegador automáticamente
+  },
 });


### PR DESCRIPTION
Closes #668 

- Added support for `Shift + Click` to enable multi-selection.  
- Verified that `Ctrl + Click` and normal `Click` still work as expected.  
- Tested in the browser, and everything is working correctly. 🚀  

![imagen](https://github.com/user-attachments/assets/667145a3-a311-4044-b4f3-22a424a4bbeb)
Here’s a visual confirmation of the feature in action:  
![Shift-Click-Selection](paste-image-here)
