### PR TITLE
Remove the relative position of the canvas 

### DIFF
--- a/src/pods/canvas/canvas.pod.module.css
+++ b/src/pods/canvas/canvas.pod.module.css
@@ -2,7 +2,6 @@
   grid-area: canvas;
   width: 100%;
   overflow: auto;
-  position: relative;
   font-family:
     Balsamiq Sans,
     Comic Sans MS,


### PR DESCRIPTION
Remove the relative position of the canvas because the calculations in the right shape menu are broken.
Closes #718 