### PR TITLE
Fix/#841 fix file content not loading

### DIFF
--- a/.changeset/tasty-steaks-know.md
+++ b/.changeset/tasty-steaks-know.md
@@ -1,0 +1,5 @@
+---
+'quickmock': patch
+---
+
+Fix editor failing to load files opened from outside the workspace. The webview HTML was assigned before registering `onDidReceiveMessage`, causing a race where the initial `READY` / `WEBVIEW_READY` message from the app could be lost and the file content never delivered. The listener is now registered before the HTML assignment.

--- a/packages/vscode-extension/src/editor/provider.ts
+++ b/packages/vscode-extension/src/editor/provider.ts
@@ -109,11 +109,6 @@ export class QuickMockEditorProvider implements vscode.CustomEditorProvider<Quic
       enableScripts: true,
       localResourceRoots: [this.extensionUri],
     };
-    panel.webview.html = getHtml(
-      panel.webview,
-      this.extensionUri,
-      getEditorAppUrl()
-    );
 
     panel.webview.onDidReceiveMessage(async (msg: AppMessage) => {
       await handleWebviewMessage(msg, doc, reply =>
@@ -121,6 +116,12 @@ export class QuickMockEditorProvider implements vscode.CustomEditorProvider<Quic
       );
       documentRegistry.set(doc.uri.fsPath, doc.content);
     });
+
+    panel.webview.html = getHtml(
+      panel.webview,
+      this.extensionUri,
+      getEditorAppUrl()
+    );
   }
 
   private broadcast(doc: QuickMockDocument, msg: HostMessage): void {


### PR DESCRIPTION
Webview HTML was being assigned before registering the onDidReceiveMessage listener, causing a race condition: the webview could emit READY/WEBVIEW_READY before the extension was listening, losing the initial message and never delivering the file content.

For files inside the workspace, activation overhead masked the race. For external files, the webview won the race consistently → empty editor.

Closes #841 