### PR TITLE
Fix/prevent cursor from jumping to end when editing component text

### DIFF
--- a/apps/web/src/common/components/inline-edit/components/html-edit.widget.tsx
+++ b/apps/web/src/common/components/inline-edit/components/html-edit.widget.tsx
@@ -38,7 +38,7 @@ export const HtmlEditWidget = forwardRef<any, Props>(
           <input
             ref={ref}
             style={{ width: '100%', height: '100%' }}
-            value={value}
+            defaultValue={value}
             onChange={handleTextChange}
             data-is-inline-edition-on="true"
           />
@@ -47,7 +47,7 @@ export const HtmlEditWidget = forwardRef<any, Props>(
           <textarea
             ref={ref}
             style={{ width: '100%', height: '100%' }}
-            value={value}
+            defaultValue={value}
             onChange={handleTextChange}
             data-is-inline-edition-on="true"
             data-testid="textareaedit"


### PR DESCRIPTION
Inline-edit inputs (shown when double-clicking a canvas component to change its text) rendered the cursor at the end of the field on every keystroke, making it impossible to move back and edit previous words. The inputs were controlled (value + onChange), but they're mounted through react-konva-utils' Html, which renders its children into a separate React root and re-renders them out-of-band on every update. Because that re-render happens outside the root that owns the input, React re-applied the DOM .value on each change and the browser reset the caret to the end.

The fix makes the <input> and <textarea> uncontrolled (defaultValue instead of value) in html-edit.widget.tsx. This is safe because the submit logic already reads the final text directly from the input ref rather than from React state, so no functional behavior changes, the caret now simply stays where the user placed it. Affects all inline-editable components (inputs, textareas, headings, paragraphs, links, etc.) since they share this widget.