### PR TITLE
Fix/canvas overlay layer for performance 

### DIFF
--- a/apps/web/src/pods/canvas/canvas.pod.tsx
+++ b/apps/web/src/pods/canvas/canvas.pod.tsx
@@ -1,23 +1,23 @@
-import React, { createRef, useEffect, useMemo, useRef, useState } from 'react';
-import Konva from 'konva';
-import { useCanvasContext, useInteractionModeContext } from '#core/providers';
-import { Layer, Line, Rect, Stage, Transformer } from 'react-konva';
-import { useTransform } from './use-transform.hook';
-import { renderShapeComponent } from './shape-renderer';
-import { useDropShape } from './use-drop-shape.hook';
-import { useMonitorShape } from './use-monitor-shape.hook';
-import { useMacWebviewDragBridge } from '#core/vscode/use-mac-webview-drag-bridge.hook';
-import classes from './canvas.pod.module.css';
 import { EditableComponent } from '#common/components/inline-edit';
-import { useSnapIn } from './use-snapin.hook';
-import { ShapeType } from '#core/model';
 import { ENV } from '#core/constants';
-import { useDropImageFromDesktop } from './use-drop-image-from-desktop';
-import { useKeyboardDisplacement } from './use-keyboard-displacement';
-import { useMultipleSelectionShapeHook } from './use-multiple-selection-shape.hook';
+import { ShapeType } from '#core/model';
+import { useCanvasContext, useInteractionModeContext } from '#core/providers';
+import { useMacWebviewDragBridge } from '#core/vscode/use-mac-webview-drag-bridge.hook';
+import Konva from 'konva';
+import React, { createRef, useEffect, useMemo, useRef, useState } from 'react';
+import { Layer, Line, Rect, Stage, Transformer } from 'react-konva';
 import { ContextMenu } from '../context-menu/use-context-menu.hook';
 import { CanvasGridLayer } from './canvas.grid';
+import classes from './canvas.pod.module.css';
 import { sampleDocument } from './sample-document';
+import { renderShapeComponent } from './shape-renderer';
+import { useDropImageFromDesktop } from './use-drop-image-from-desktop';
+import { useDropShape } from './use-drop-shape.hook';
+import { useKeyboardDisplacement } from './use-keyboard-displacement';
+import { useMonitorShape } from './use-monitor-shape.hook';
+import { useMultipleSelectionShapeHook } from './use-multiple-selection-shape.hook';
+import { useSnapIn } from './use-snapin.hook';
+import { useTransform } from './use-transform.hook';
 
 export const CanvasPod = () => {
   const [isTransfomerBeingDragged, setIsTransfomerBeingDragged] =
@@ -236,6 +236,8 @@ export const CanvasPod = () => {
               onDragEnd={() => setIsTransfomerBeingDragged(false)}
             />
           )}
+        </Layer>
+        <Layer listening={false}>
           {isTransfomerBeingDragged && showSnapInHorizontalLine && (
             <Line
               points={[


### PR DESCRIPTION
This change splits the canvas content into two Konva layers. Until now, all shapes, the `Transformer`, the snap guide lines, and the rubber-band selection rectangle lived on a single `<Layer>`. Since Konva's `batchDraw` re-rasterizes the entire layer whenever any node changes, every per-frame update of the selection rectangle or the snap guides forced a redraw of **every** shape on the canvas. With many elements on screen this caused noticeable stutters, especially during rubber-band selection.

The fix moves the snap lines and the selection rectangle onto a new overlay layer with `listening={false}`, so their per-frame updates only re-rasterize that layer (a couple of purely visual nodes) instead of the shapes layer. The `listening={false}` flag also prevents Konva from maintaining a hit canvas for those nodes and stops them from intercepting pointer events meant for the `Stage`. The `Transformer` is deliberately kept on the main layer, because dragging it moves the shape nodes along with it (they redraw together anyway, so relocating it would bring no benefit) and because the e2e helpers locate it there. The change is additive and low-risk; it targets Konva's rasterization cost, not React's reconciliation, which remains the next optimization step.
